### PR TITLE
Add system healthcheck endpoint

### DIFF
--- a/config/modules.yaml
+++ b/config/modules.yaml
@@ -1,3 +1,4 @@
 imports:
   - { resource: "../src/Shared/Infrastructure/DependencyInjection/_module.yaml" }
+  - { resource: "../src/Module/System/Infrastructure/DependencyInjection/_module.yaml" }
   - { resource: "../src/Module/User/Infrastructure/DependencyInjection/_module.yaml" }

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -1,2 +1,5 @@
+system_routing:
+    resource: '../src/Module/System/Infrastructure/DependencyInjection/routes.yaml'
+
 users_routing:
     resource: '../src/Module/User/Infrastructure/DependencyInjection/routes.yaml'

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -18,4 +18,6 @@ parameters:
     excludePaths:
        - .docker
        - migrations
+       - %rootDir%/functions.php
+       - tests
     inferPrivatePropertyTypeFromConstructor: true

--- a/src/Module/System/Application/Get/GetSystemStatusQuery.php
+++ b/src/Module/System/Application/Get/GetSystemStatusQuery.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BetaReaders\Module\System\Application\Get;
+
+use BetaReaders\Shared\Domain\Bus\Query\Query;
+
+final class GetSystemStatusQuery implements Query
+{
+}

--- a/src/Module/System/Application/Get/GetSystemStatusQueryHandler.php
+++ b/src/Module/System/Application/Get/GetSystemStatusQueryHandler.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BetaReaders\Module\System\Application\Get;
+
+use BetaReaders\Module\System\Application\SystemResponse;
+use BetaReaders\Shared\Domain\Uid\UlidProvider;
+
+final class GetSystemStatusQueryHandler
+{
+    public function __construct(private readonly UlidProvider $ulidProvider)
+    {
+    }
+
+    public function __invoke(GetSystemStatusQuery $query): SystemResponse
+    {
+        return SystemResponse::withId($this->ulidProvider->new()->value());
+    }
+}

--- a/src/Module/System/Application/SystemResponse.php
+++ b/src/Module/System/Application/SystemResponse.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BetaReaders\Module\System\Application;
+
+use BetaReaders\Shared\Domain\Bus\Query\Response;
+
+final class SystemResponse implements Response
+{
+    public function __construct(private readonly string $id, private readonly bool $result)
+    {
+    }
+
+    public static function withId(string $id): SystemResponse
+    {
+        return new self($id, true);
+    }
+
+    public function toPlain(): array
+    {
+        return [
+            'id' => $this->id,
+            'result' => $this->result,
+        ];
+    }
+}

--- a/src/Module/System/Infrastructure/DependencyInjection/_module.yaml
+++ b/src/Module/System/Infrastructure/DependencyInjection/_module.yaml
@@ -1,0 +1,5 @@
+imports:
+  - { resource: infrastructure.yaml }
+  - { resource: application.yaml }
+#  - { resource: domain.yaml }
+#  - { resource: doctrine.yaml }

--- a/src/Module/System/Infrastructure/DependencyInjection/application.yaml
+++ b/src/Module/System/Infrastructure/DependencyInjection/application.yaml
@@ -1,0 +1,7 @@
+services:
+
+  BetaReaders\Module\System\Application\Get\GetSystemStatusQueryHandler:
+    arguments:
+      $ulidProvider: '@BetaReaders\Shared\Domain\Uid\UlidProvider'
+    tags:
+      - { name: tactician.handler, typehints: true }

--- a/src/Module/System/Infrastructure/DependencyInjection/infrastructure.yaml
+++ b/src/Module/System/Infrastructure/DependencyInjection/infrastructure.yaml
@@ -1,0 +1,26 @@
+services:
+  beta_readers.system.http.json_body_guard:
+    class: BetaReaders\Shared\Infrastructure\Validation\JsonSchema\JsonSchemaGuard
+    arguments:
+      $filesystem: '@filesystem'
+      $schemasRootPath: ''
+      $formatter: '@BetaReaders\Shared\Infrastructure\Validation\JsonSchema\JsonSchemaErrorFormatter'
+
+  beta_readers.system.http.json_api_controller:
+    class: BetaReaders\Shared\Infrastructure\Entrypoint\Http\JsonApiController
+    arguments:
+      $queryBus: '@BetaReaders\Shared\Infrastructure\Bus\Query\TacticianSyncQueryBus'
+      $commandBus: '@BetaReaders\Shared\Infrastructure\Bus\Command\TacticianSyncCommandBus'
+      $bodyGuard: '@beta_readers.system.http.json_body_guard'
+      $exceptionHandler: '@BetaReaders\Shared\Infrastructure\Entrypoint\Http\HttpExceptionsHandler'
+
+  BetaReaders\Module\System\Infrastructure\Response\JsonApi\SystemJsonApiSchemaRegisterer:
+    tags:
+      - { name: beta_readers.json_api_schema_registerer }
+
+  BetaReaders\Module\System\Infrastructure\UI\Controller\GetSystemStatusController:
+    parent: beta_readers.system.http.json_api_controller
+    public: true
+    autowire: true
+    tags:
+      - controller.service_arguments

--- a/src/Module/System/Infrastructure/DependencyInjection/routes.yaml
+++ b/src/Module/System/Infrastructure/DependencyInjection/routes.yaml
@@ -1,0 +1,4 @@
+system.healthcheck:
+  path: /system/healthcheck
+  methods: [GET]
+  defaults: { _controller: BetaReaders\Module\System\Infrastructure\UI\Controller\GetSystemStatusController }

--- a/src/Module/System/Infrastructure/Response/JsonApi/SystemJsonApiSchemaRegisterer.php
+++ b/src/Module/System/Infrastructure/Response/JsonApi/SystemJsonApiSchemaRegisterer.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BetaReaders\Module\System\Infrastructure\Response\JsonApi;
+
+use BetaReaders\Module\System\Application\SystemResponse;
+use BetaReaders\Shared\Infrastructure\Response\JsonApi\JsonApiSchemaMapping;
+use BetaReaders\Shared\Infrastructure\Response\JsonApi\JsonApiSchemaRegisterer;
+
+final class SystemJsonApiSchemaRegisterer implements JsonApiSchemaRegisterer
+{
+    public function registerer(): \Closure
+    {
+        return function (JsonApiSchemaMapping $mapping): void {
+            $mapping->add(SystemResponse::class, SystemResponseJsonApiSchema::class);
+        };
+    }
+}

--- a/src/Module/System/Infrastructure/Response/JsonApi/SystemResponseJsonApiSchema.php
+++ b/src/Module/System/Infrastructure/Response/JsonApi/SystemResponseJsonApiSchema.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BetaReaders\Module\System\Infrastructure\Response\JsonApi;
+
+use BetaReaders\Module\System\Application\SystemResponse;
+use Neomerx\JsonApi\Contracts\Schema\ContextInterface;
+use Neomerx\JsonApi\Contracts\Schema\SchemaInterface;
+use Neomerx\JsonApi\Schema\BaseSchema;
+
+final class SystemResponseJsonApiSchema extends BaseSchema implements SchemaInterface
+{
+    public function getType(): string
+    {
+        return 'healthcheck';
+    }
+
+    /**
+     * @param SystemResponse $resource
+     */
+    public function getId($resource): ?string
+    {
+        return $resource->toPlain()['id'];
+    }
+
+    /**
+     * @param SystemResponse $resource
+     */
+    public function getAttributes($resource, ContextInterface $context): iterable
+    {
+        return $resource->toPlain();
+    }
+
+    public function getRelationships($resource, ContextInterface $context): iterable
+    {
+        return [];
+    }
+
+    public function getLinks($resource): iterable
+    {
+        return [];
+    }
+}

--- a/src/Module/System/Infrastructure/UI/Controller/GetSystemStatusController.php
+++ b/src/Module/System/Infrastructure/UI/Controller/GetSystemStatusController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BetaReaders\Module\System\Infrastructure\UI\Controller;
+
+use BetaReaders\Module\System\Application\Get\GetSystemStatusQuery;
+use BetaReaders\Shared\Infrastructure\Entrypoint\Http\JsonApiController;
+use BetaReaders\Shared\Infrastructure\Response\JsonApi\JsonApiOkResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+final class GetSystemStatusController extends JsonApiController
+{
+    protected function exceptions(): array
+    {
+        return [];
+    }
+
+    public function __invoke(Request $request): JsonApiOkResponse
+    {
+        $response = $this->ask(new GetSystemStatusQuery());
+
+        return new JsonApiOkResponse($response);
+    }
+}

--- a/src/Shared/Infrastructure/Response/JsonApi/JsonApiResponseEncoder.php
+++ b/src/Shared/Infrastructure/Response/JsonApi/JsonApiResponseEncoder.php
@@ -35,7 +35,9 @@ final class JsonApiResponseEncoder
         }
 
         $includes = $this->fetchIncludesFromRequest();
-        $encoder = Encoder::instance($this->mapping->all())->withIncludedPaths($includes);
+        $encoder = Encoder::instance($this->mapping->all())
+            ->withLinks([])
+            ->withIncludedPaths($includes);
 
         if ($jsonApiResponse instanceof JsonApiPaginatedResponse) {
             return $encoder->withMeta($jsonApiResponse->metadata());
@@ -53,9 +55,12 @@ final class JsonApiResponseEncoder
 
     private function inferResponseClass(ApiHttpResponse $response): string
     {
-        return $response instanceof JsonApiPaginatedResponse
+        /** @var string $responseClass */
+        $responseClass = $response instanceof JsonApiPaginatedResponse
             ? $response->type()
-            : get_class($response);
+            : get_class($response->data());
+
+        return $responseClass;
     }
 
     private function contentByResourceType(ApiHttpResponse $response): mixed

--- a/tests/feature/Module/System/Infrastructure/UI/GetSystemStatusControllerAcceptanceTest.php
+++ b/tests/feature/Module/System/Infrastructure/UI/GetSystemStatusControllerAcceptanceTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BetaReaders\Tests\Module\System\Infrastructure\UI;
+
+use BetaReaders\Packages\PHPUnit\Symfony\AcceptanceTests;
+
+use function Lambdish\Phunctional\get_in;
+
+final class GetSystemStatusControllerAcceptanceTest extends AcceptanceTests
+{
+    /**
+     * @test
+     */
+    public function itShouldAnswerOkIfTheSystemIsReady(): void
+    {
+        $response = $this->httpGet($this->route('/system/healthcheck'));
+        $this->thenTheResponseCodeShouldBe(200);
+        $this->assertTrue(get_in(['data', 'attributes', 'result'], $response));
+    }
+}


### PR DESCRIPTION
Provide an endpoint to check if the application is ready to receive requests with a basic approach and without any infra check

* This endpoint must be considered really useful in most of the use cases related to deploy a containerized application, in order to know if the container / pod is active, running and able to receive new incoming requests from outside.

* Feel free to manifest any doubt or question about the taken approach, all questions are more than welcome, keep in mind we need to build a knowledge base from its roots and it's really important avoid knowledge silos regardless the level of each one.